### PR TITLE
feat(media): enable Jackett auto-update

### DIFF
--- a/media/docker-compose.yml
+++ b/media/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - PUID=${PUID}
       - PGID=${PGID}
       - TZ=${TZ}
+      - AUTO_UPDATE=true
     volumes:
       - jackett_config:/config
       - ./data:/data


### PR DESCRIPTION
Enable Jackett's internal auto-update via the LinuxServer.io `AUTO_UPDATE` environment variable.

| File | Change |
|------|--------|
| `media/docker-compose.yml` | Added `AUTO_UPDATE=true` to the jackett service environment |

Test plan:
- [x] `docker compose config` validates the modified compose file